### PR TITLE
Hopefully finish ruma_identifiers migration

### DIFF
--- a/src/models/auth.rs
+++ b/src/models/auth.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use ruma_identifiers::UserId;
+use ruma_identifiers::{DeviceId, UserId};
 
 use crate::CONFIG;
 
@@ -32,7 +32,7 @@ pub struct LoginRequest {
     #[serde(flatten)]
     pub challenge: Challenge,
     pub identifier: UserId,
-    pub device_id: Option<String>,
+    pub device_id: Option<DeviceId>,
     pub initial_device_display_name: Option<String>,
 }
 
@@ -52,6 +52,6 @@ pub struct DiscoveryInfo {
 pub struct LoginResponse {
     pub user_id: UserId,
     pub access_token: String,
-    pub device_id: String,
+    pub device_id: DeviceId,
     pub well_known: DiscoveryInfo,
 }

--- a/src/models/registration.rs
+++ b/src/models/registration.rs
@@ -1,3 +1,4 @@
+use ruma_identifiers::DeviceId;
 use serde::Deserialize;
 
 /// The kind of account to register.
@@ -36,7 +37,7 @@ pub struct Request {
     /// ID of the client device. If this does not correspond to a known
     /// client device, a new device will be created. The server will
     /// auto-generate a device_id if this is not specified.
-    pub device_id: Option<String>,
+    pub device_id: Option<DeviceId>,
     /// If true, an `access_token` and `device_id` should not be returned
     /// from this call, therefore preventing an automatic login. Defaults
     /// to `false`.

--- a/src/server/handlers/auth.rs
+++ b/src/server/handlers/auth.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use actix_web::{http::StatusCode, web::Json, Error, HttpResponse};
 use jsonwebtoken as jwt;
-use ruma_identifiers::UserId;
+use ruma_identifiers::{DeviceId, UserId};
 use serde_json::json;
 
 use crate::{
@@ -42,10 +42,10 @@ pub struct Claims<'a, 'b> {
     pub iat: i64,
     pub exp: i64,
     pub sub: &'a UserId,
-    pub device_id: &'b str,
+    pub device_id: &'b DeviceId,
 }
 impl<'a, 'b> Claims<'a, 'b> {
-    pub fn new(user_id: &'a UserId, device_id: &'b str) -> Self {
+    pub fn new(user_id: &'a UserId, device_id: &'b DeviceId) -> Self {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|a| a.as_secs() as i64)
@@ -69,7 +69,7 @@ pub async fn login(req: Json<model::LoginRequest>) -> Result<HttpResponse, Error
             unimplemented!("check OTP against user db") // TODO: will finish once user db model is complete
         }
     };
-    let device_id: String = unimplemented!("find or create device id");
+    let device_id = ruma_identifiers::device_id::generate(); // TODO: implement method of finding existing device_id and verifying generated id does not collide
     let access_token = jwt::encode(
         &jwt::Header::new(jwt::Algorithm::ES256),
         &Claims::new(&user_id, &device_id),


### PR DESCRIPTION
Now have `DeviceId` migrated to `ruma_identifiers`. Also used built in `DeviceId` generator.

`DeviceId` is defined as `pub type DeviceId = String` and is merely used for more clear syntax. The generated IDs are 8 random alphanumeric chars.