### PR TITLE
Adds Store Error & Mock Storage

### DIFF
--- a/src/db/mock.rs
+++ b/src/db/mock.rs
@@ -1,0 +1,51 @@
+use std::borrow::Cow;
+
+use async_trait::async_trait;
+use ruma_identifiers::{DeviceId, UserId};
+
+use super::{Error, Store};
+use crate::models::auth::{PWHash, UserIdentifier};
+
+/// A Mock Storage engine used for Testing.
+
+#[derive(Clone)]
+pub struct MockStore {
+    pub check_username_exists_resp: Option<Result<bool, Error>>,
+}
+
+#[async_trait]
+impl Store for MockStore {
+    fn get_type(&self) -> String {
+        "MockStore".to_string()
+    }
+
+    async fn check_username_exists(&self, _username: &str) -> Result<bool, Error> {
+        self.check_username_exists_resp
+            .clone()
+            .expect("check_username_exists_resp not set.")
+    }
+
+    async fn fetch_user_id<'a>(
+        &self,
+        _user_id: &'a UserIdentifier,
+    ) -> Result<Option<Cow<'a, UserId>>, Error> {
+        unimplemented!()
+    }
+
+    async fn fetch_password_hash(&self, _user_id: &UserId) -> Result<PWHash, Error> {
+        unimplemented!()
+    }
+
+    async fn check_otp_exists(&self, _user_id: &UserId, _otp: &str) -> Result<bool, Error> {
+        unimplemented!()
+    }
+
+    async fn set_device<'a>(
+        &self,
+        _user_id: &UserId,
+        _device_id: &DeviceId,
+        _display_name: Option<&str>,
+    ) -> Result<(), Error> {
+        unimplemented!()
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,9 +1,11 @@
+pub mod mock;
 pub mod postgres;
 
 pub use postgres::PostgresStore;
 
+use std;
 use std::borrow::Cow;
-use std::error::Error;
+use std::fmt;
 
 use async_trait::async_trait;
 use ruma_identifiers::{DeviceId, UserId};
@@ -19,23 +21,74 @@ pub trait Store: Clone + Sync + Send + Sized {
     /// Gets the type of this data store, e.g. Postgres
     fn get_type(&self) -> String;
 
-    /// Determines if a username is available for registration.
-    /// TODO: Create more generic error responses
-    async fn check_username_exists(&self, username: &str) -> Result<bool, Box<dyn Error>>;
+    /// checks if username exists
+    async fn check_username_exists(&self, username: &str) -> Result<bool, Error>;
 
     async fn fetch_user_id<'a>(
         &self,
         user_id: &'a UserIdentifier,
-    ) -> Result<Option<Cow<'a, UserId>>, Box<dyn Error>>;
+    ) -> Result<Option<Cow<'a, UserId>>, Error>;
 
-    async fn fetch_password_hash(&self, user_id: &UserId) -> Result<PWHash, Box<dyn Error>>;
+    async fn fetch_password_hash(&self, user_id: &UserId) -> Result<PWHash, Error>;
 
-    async fn check_otp_exists(&self, user_id: &UserId, otp: &str) -> Result<bool, Box<dyn Error>>;
+    async fn check_otp_exists(&self, user_id: &UserId, otp: &str) -> Result<bool, Error>;
 
     async fn set_device<'a>(
         &self,
         user_id: &UserId,
         device_id: &DeviceId,
         display_name: Option<&str>,
-    ) -> Result<(), Box<dyn Error>>;
+    ) -> Result<(), Error>;
+}
+
+/// Store Error
+///
+/// Errors returned from implementaitons of the `Store`
+/// trait.
+#[derive(Debug, Clone)]
+pub struct Error {
+    // TODO: Implement source error
+    pub code: ErrorCode,
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.code {
+            // TODO: implment source error and chain dispaly
+            ErrorCode::ConnectionFailed => write!(f, "Connection failed."),
+            ErrorCode::AuthFailed => write!(f, "Authentication failed."),
+            ErrorCode::RecordNotFound => write!(f, "The data store could not find any records."),
+            ErrorCode::DuplicateViolation => {
+                write!(f, "A Key or Unique constraint has been violated.")
+            }
+            ErrorCode::NullViolation => write!(f, "A non-Null constraint was violated."),
+            ErrorCode::InvalidSyntax => write!(f, "The query contained invalid syntax."),
+            _ => write!(f, "An unknown error has occurred."),
+        }
+    }
+}
+
+/// A generic list of error codes returned from storge/db servers.
+///
+/// Used to simplify error handling responsed from different storage
+/// servers.  The actual implementation of the `Store` trait should use
+/// additional logging to monitor for more granular and specific errors.
+#[derive(Debug, Clone)]
+pub enum ErrorCode {
+    /// Cant connect to the storage/db server.
+    ConnectionFailed,
+    /// Authorization credentials failed.
+    AuthFailed,
+    /// Row/Record not found.
+    RecordNotFound,
+    /// A Unique Key or Duplicate Constaint check was violated.
+    DuplicateViolation,
+    /// A non-null check was violated.
+    NullViolation,
+    /// The query syntax was invalid.
+    InvalidSyntax,
+    /// Catch all for any error that can be translated to one of the existing errors.
+    Unknown,
 }

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -1,14 +1,30 @@
 use std::borrow::Cow;
-use std::error::Error;
 
 use async_trait::async_trait;
 use ruma_identifiers::{DeviceId, UserId};
 use sqlx::postgres::PgPool;
 use sqlx::postgres::PgQueryAs;
 
-use super::Store;
+use super::{Error, ErrorCode, Store};
 use crate::models::auth::{PWHash, UserIdentifier};
 
+// Convert from Sqlx errors to Store errors
+impl From<sqlx::Error> for Error {
+    #[inline]
+    fn from(err: sqlx::Error) -> Self {
+        let code = match err {
+            sqlx::Error::Io(_) | sqlx::Error::PoolClosed | sqlx::Error::PoolTimedOut(_) => {
+                ErrorCode::ConnectionFailed
+            }
+            sqlx::Error::RowNotFound => ErrorCode::RecordNotFound,
+            //TODO: break out and match against database errors
+            sqlx::Error::Database(_) | sqlx::Error::ColumnNotFound(_) => ErrorCode::InvalidSyntax,
+            _ => ErrorCode::Unknown,
+        };
+
+        Error { code }
+    }
+}
 /// A Postgres Data Store
 ///
 /// This implements the `Store` trait for Postgres.
@@ -33,10 +49,10 @@ impl PostgresStore {
 #[async_trait]
 impl Store for PostgresStore {
     fn get_type(&self) -> String {
-        "Initialized PostgresStore".to_string()
+        "PostgresStore".to_string()
     }
 
-    async fn check_username_exists(&self, username: &str) -> Result<bool, Box<dyn Error>> {
+    async fn check_username_exists(&self, username: &str) -> Result<bool, Error> {
         let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM accounts where localpart = $1")
             .bind(username)
             .fetch_one(&self.pool)
@@ -48,15 +64,15 @@ impl Store for PostgresStore {
     async fn fetch_user_id<'a>(
         &self,
         user_id: &'a UserIdentifier,
-    ) -> Result<Option<Cow<'a, UserId>>, Box<dyn Error>> {
+    ) -> Result<Option<Cow<'a, UserId>>, Error> {
         unimplemented!()
     }
 
-    async fn fetch_password_hash(&self, user_id: &UserId) -> Result<PWHash, Box<dyn Error>> {
+    async fn fetch_password_hash(&self, user_id: &UserId) -> Result<PWHash, Error> {
         unimplemented!()
     }
 
-    async fn check_otp_exists(&self, user_id: &UserId, otp: &str) -> Result<bool, Box<dyn Error>> {
+    async fn check_otp_exists(&self, user_id: &UserId, otp: &str) -> Result<bool, Error> {
         unimplemented!()
     }
 
@@ -65,7 +81,7 @@ impl Store for PostgresStore {
         user_id: &UserId,
         device_id: &DeviceId,
         display_name: Option<&str>,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<(), Error> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
This PR starts the work for creating a concrete error type for `Store` trait.
- Adds `db::Error` and `db::MockStorage`
- renames `is_username_available` to `check_username_exists`
