### PR TITLE
Bump supported version and fix available route

### DIFF
--- a/src/server/handlers/admin.rs
+++ b/src/server/handlers/admin.rs
@@ -33,7 +33,7 @@ pub async fn get_wellknown() -> Result<HttpResponse, Error> {
 pub async fn get_versions() -> Result<HttpResponse, Error> {
     Ok(HttpResponse::Ok()
         .content_type("application/json")
-        .body("{\"versions\":[\"r0.5.0\"]}"))
+        .body("{\"versions\":[\"r0.6.0\"]}"))
 }
 
 #[cfg(test)]

--- a/src/server/handlers/registration.rs
+++ b/src/server/handlers/registration.rs
@@ -48,7 +48,7 @@ pub async fn get_available<T: Store>(
             "Desired user ID is already taken.",
         ))?
     } else {
-        Ok(HttpResponse::Ok().json(json!({"avaiable": true})))
+        Ok(HttpResponse::Ok().json(json!({"available": true})))
     }
 }
 


### PR DESCRIPTION
- Bump supported version from 0.5.0 to 0.6.0 (all issues links to
  v0.6.0)
- Fix typo on `/_matrix/client/r0/register/available`