### PR TITLE
Add getDisplayName endpoint

### DIFF
--- a/schema/postgres.sql
+++ b/schema/postgres.sql
@@ -20,6 +20,17 @@ CREATE TABLE IF NOT EXISTS accounts (
   is_guest bool DEFAULT FALSE NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_accounts_is_guest ON accounts(is_guest);
+
+DROP TABLE IF EXISTS account_profiles;
+CREATE TABLE IF NOT EXISTS account_profiles (
+  -- The Matrix user ID localpart for this account
+  localpart TEXT NOT NULL PRIMARY KEY,
+  -- The display name for this account
+  display_name TEXT,
+  -- The URL of the avatar for this account
+  avatar_url TEXT
+);
+
 ----------------
 -- Devices
 ----------------

--- a/src/db/mock.rs
+++ b/src/db/mock.rs
@@ -73,6 +73,10 @@ impl Store for MockStore {
         unimplemented!()
     }
 
+    async fn fetch_display_name(&self, _user_id: &UserId) -> Result<String, Error> {
+        unimplemented!()
+    }
+
     async fn check_otp_exists(&self, _user_id: &UserId, _otp: &str) -> Result<bool, Error> {
         unimplemented!()
     }

--- a/src/db/mock.rs
+++ b/src/db/mock.rs
@@ -74,7 +74,7 @@ impl Store for MockStore {
     }
 
     async fn fetch_display_name(&self, _user_id: &UserId) -> Result<String, Error> {
-        unimplemented!()
+        return Ok(String::from("testDisplayName"));
     }
 
     async fn check_otp_exists(&self, _user_id: &UserId, _otp: &str) -> Result<bool, Error> {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -41,6 +41,8 @@ pub trait Store: Clone + Sync + Send + Sized {
 
     async fn fetch_password_hash(&self, user_id: &UserId) -> Result<PWHash, Error>;
 
+    async fn fetch_display_name(&self, user_id: &UserId) -> Result<String, Error>;
+
     async fn check_otp_exists(&self, user_id: &UserId, otp: &str) -> Result<bool, Error>;
 
     async fn set_device<'a>(

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -72,6 +72,16 @@ impl Store for PostgresStore {
         unimplemented!()
     }
 
+    async fn fetch_display_name(&self, user_id: &UserId) -> Result<String, Error> {
+        let row: (String,) =
+            sqlx::query_as("SELECT display_name FROM account_profiles WHERE localpart = $1")
+                .bind(user_id.localpart())
+                .fetch_one(&self.pool)
+                .await?;
+
+        Ok(row.0)
+    }
+
     async fn check_otp_exists(&self, user_id: &UserId, otp: &str) -> Result<bool, Error> {
         unimplemented!()
     }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,3 +1,4 @@
 pub mod account;
 pub mod auth;
+pub mod profile;
 pub mod registration;

--- a/src/models/profile.rs
+++ b/src/models/profile.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct DisplayNameResponse {
     pub displayname: String,
 }

--- a/src/models/profile.rs
+++ b/src/models/profile.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DisplayNameResponse {
+    pub displayname: String,
+}

--- a/src/server/handlers/profile.rs
+++ b/src/server/handlers/profile.rs
@@ -17,10 +17,13 @@ pub async fn get_displayname<T: Store>(
     req: Path<String>,
     storage: Data<T>,
 ) -> Result<HttpResponse, Error> {
-    let userId = UserId::try_from(req.into_inner())
+    let user_id = UserId::try_from(req.into_inner())
         .with_codes(StatusCode::BAD_REQUEST, ErrorCode::INVALID_PARAM)?;
+    let display_name = storage.fetch_display_name(&user_id).await
+        .with_codes(StatusCode::NOT_FOUND, ErrorCode::UNKNOWN)?;
+
     Ok(HttpResponse::Ok()
         .json(profile_model::DisplayNameResponse {
-            displayname: String::from(userId),
+            displayname: display_name,
     }))
 }

--- a/src/server/handlers/profile.rs
+++ b/src/server/handlers/profile.rs
@@ -1,6 +1,7 @@
 use std::convert::{TryFrom, From};
 
 use actix_web::{
+    http::StatusCode,
     web::{Data, Path},
     Error, HttpRequest, HttpResponse};
 
@@ -8,14 +9,16 @@ use ruma_identifiers::UserId;
 
 use crate::{
     models::profile as profile_model,
-    db::Store
+    db::Store,
+    server::error::{ResultExt, ErrorCode},
 };
 
 pub async fn get_displayname<T: Store>(
     req: Path<String>,
     storage: Data<T>,
 ) -> Result<HttpResponse, Error> {
-    let userId = UserId::try_from(req.into_inner()).unwrap();
+    let userId = UserId::try_from(req.into_inner())
+        .with_codes(StatusCode::BAD_REQUEST, ErrorCode::INVALID_PARAM)?;
     Ok(HttpResponse::Ok()
         .json(profile_model::DisplayNameResponse {
             displayname: String::from(userId),

--- a/src/server/handlers/profile.rs
+++ b/src/server/handlers/profile.rs
@@ -1,1 +1,23 @@
+use std::convert::{TryFrom, From};
 
+use actix_web::{
+    web::{Data, Path},
+    Error, HttpRequest, HttpResponse};
+
+use ruma_identifiers::UserId;
+
+use crate::{
+    models::profile as profile_model,
+    db::Store
+};
+
+pub async fn get_displayname<T: Store>(
+    req: Path<String>,
+    storage: Data<T>,
+) -> Result<HttpResponse, Error> {
+    let userId = UserId::try_from(req.into_inner()).unwrap();
+    Ok(HttpResponse::Ok()
+        .json(profile_model::DisplayNameResponse {
+            displayname: String::from(userId),
+    }))
+}

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -44,6 +44,13 @@ pub fn config<T: Store + 'static>(cfg: &mut ServiceConfig) {
                 resource("/account/whoami")
                     .route(get().to(handlers::account::whoami))
                     .wrap(AuthChecker::<T>::new()),
+            )
+            .service(
+                scope("/profile")
+                    .service(
+                        resource("/{userId}/displayname")
+                            .route(get().to(handlers::profile::get_displayname::<T>))
+                    )
             ),
     );
 }


### PR DESCRIPTION
Addressing issue #34 

For the postgres schema changes, I referenced Dendrite: https://github.com/matrix-org/dendrite/blob/master/clientapi/auth/storage/accounts/postgres/profile_table.go. Does this seem reasonable, or would we prefer something else?

I also wasn't sure if I should create a struct for the response, or just serialize the displayname string directly in the handler. I saw that the whoami handler used a struct so that's the pattern I followed.

Feedback greatly appreciated!